### PR TITLE
Build with Zig 0.15.2 and bump googletest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,12 @@ jobs:
         ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.15.2
 
       - name: Build
-        run: zig build -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }}
+        run: zig build samples -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# googletest
+
+This is [googletest](https://github.com/google/googletest), packaged for
+[Zig](https://ziglang.org/).
+
+## How to use it
+
+First, update your `build.zig.zon`:
+
+```
+zig fetch --save git+https://github.com/allyourcodebase/googletest
+```
+
+Next, in `build.zig`, declare the dependency and link your test with the static libraries:
+
+```zig
+const googletest_dep = b.dependency("googletest", .{
+    .target = target,
+    .optimize = optimize,
+});
+
+const tests_exe = b.addExecutable(.{
+    .name = "tests",
+    .root_module = b.createModule(.{ .target = target, .optimize = optimize }),
+});
+tests_exe.addCSourceFiles(.{ .files = &.{"src/tests.cpp"} }); // your test files
+tests_exe.linkLibrary(googletest_dep.artifact("gtest"));
+// Unless you define your own entry point, you need `gtest_main` too.
+tests_exe.linkLibrary(googletest_dep.artifact("gtest_main"));
+```

--- a/build.zig
+++ b/build.zig
@@ -40,6 +40,24 @@ pub fn build(b: *std.Build) void {
     gtest_main.installHeadersDirectory(gtest_dep.path("googletest/include"), ".", .{});
     b.installArtifact(gtest_main);
 
+    const gmock = b.addLibrary(.{
+        .name = "gmock",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    gmock.root_module.addCSourceFile(.{
+        .file = gtest_dep.path("googlemock/src/gmock-all.cc"),
+        .flags = &.{"-std=c++17"},
+    });
+    gmock.linkLibCpp();
+    gmock.addIncludePath(gtest_dep.path("googlemock/include"));
+    gmock.addIncludePath(gtest_dep.path("googlemock"));
+    gmock.installHeadersDirectory(gtest_dep.path("googlemock/include"), ".", .{});
+    gmock.linkLibrary(gtest);
+    b.installArtifact(gmock);
+
     const samples_exe = b.addExecutable(.{
         .name = "gtest_samples",
         .root_module = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -6,36 +6,39 @@ pub fn build(b: *std.Build) void {
 
     const googletest_dep = b.dependency("googletest", .{});
 
-    const gtest = b.addStaticLibrary(.{
+    const gtest = b.addLibrary(.{
         .name = "gtest",
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
+    gtest.linkLibC();
     gtest.linkLibCpp();
-    gtest.addCSourceFile(.{
+    gtest.root_module.addCSourceFile(.{
         .file = googletest_dep.path("googletest/src/gtest-all.cc"),
         .flags = &.{},
     });
-    gtest.addIncludePath(googletest_dep.path("googletest/include"));
-    gtest.addIncludePath(googletest_dep.path("googletest"));
+    gtest.root_module.addIncludePath(googletest_dep.path("googletest/include"));
+    gtest.root_module.addIncludePath(googletest_dep.path("googletest"));
     gtest.installHeadersDirectory(googletest_dep.path("googletest/include"), ".", .{});
-
     b.installArtifact(gtest);
 
-    const gtest_main = b.addStaticLibrary(.{
+    const gtest_main = b.addLibrary(.{
         .name = "gtest_main",
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
+    gtest_main.linkLibC();
     gtest_main.linkLibCpp();
-    gtest_main.addCSourceFile(.{
+    gtest_main.root_module.addCSourceFile(.{
         .file = googletest_dep.path("googletest/src/gtest_main.cc"),
         .flags = &.{},
     });
-    gtest_main.addIncludePath(googletest_dep.path("googletest/include"));
-    gtest_main.addIncludePath(googletest_dep.path("googletest"));
+    gtest_main.root_module.addIncludePath(googletest_dep.path("googletest/include"));
+    gtest_main.root_module.addIncludePath(googletest_dep.path("googletest"));
     gtest_main.installHeadersDirectory(googletest_dep.path("googletest/include"), ".", .{});
     b.installArtifact(gtest_main);
 }

--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    gtest.linkLibC();
     gtest.linkLibCpp();
     gtest.root_module.addCSourceFile(.{
         .file = gtest_dep.path("googletest/src/gtest-all.cc"),
@@ -31,7 +30,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    gtest_main.linkLibC();
     gtest_main.linkLibCpp();
     gtest_main.root_module.addCSourceFile(.{
         .file = gtest_dep.path("googletest/src/gtest_main.cc"),

--- a/build.zig
+++ b/build.zig
@@ -41,4 +41,68 @@ pub fn build(b: *std.Build) void {
     gtest_main.root_module.addIncludePath(gtest_dep.path("googletest"));
     gtest_main.installHeadersDirectory(gtest_dep.path("googletest/include"), ".", .{});
     b.installArtifact(gtest_main);
+
+    const samples_exe = b.addExecutable(.{
+        .name = "gtest_samples",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    samples_exe.addCSourceFiles(.{
+        .root = gtest_dep.path("googletest/samples"),
+        .files = &.{
+            "sample1_unittest.cc",
+            "sample1.cc",
+            "sample2_unittest.cc",
+            "sample2.cc",
+            "sample3_unittest.cc",
+            "sample4_unittest.cc",
+            "sample4.cc",
+            "sample5_unittest.cc",
+            "sample6_unittest.cc",
+            "sample7_unittest.cc",
+            "sample8_unittest.cc",
+        },
+    });
+    samples_exe.linkLibrary(gtest);
+    samples_exe.linkLibrary(gtest_main);
+    b.installArtifact(samples_exe);
+
+    // Samples 9 and 10 define their own entrypoint.
+    const sample9_exe = b.addExecutable(.{
+        .name = "gtest_sample9",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    sample9_exe.addCSourceFiles(.{
+        .root = gtest_dep.path("googletest/samples"),
+        .files = &.{
+            "sample9_unittest.cc",
+        },
+    });
+    sample9_exe.linkLibrary(gtest);
+    b.installArtifact(sample9_exe);
+
+    const sample10_exe = b.addExecutable(.{
+        .name = "gtest_sample10",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    sample10_exe.addCSourceFiles(.{
+        .root = gtest_dep.path("googletest/samples"),
+        .files = &.{"sample10_unittest.cc"},
+    });
+    sample10_exe.linkLibrary(gtest);
+    b.installArtifact(sample10_exe);
+
+    const samples_step = b.step("samples", "Build the sample tests");
+    samples_step.dependOn(&samples_exe.step);
+    samples_step.dependOn(&sample9_exe.step);
+    samples_step.dependOn(&sample10_exe.step);
+    samples_step.dependOn(b.getInstallStep());
 }

--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
     gtest.linkLibCpp();
     gtest.root_module.addCSourceFile(.{
         .file = gtest_dep.path("googletest/src/gtest-all.cc"),
-        .flags = &.{},
+        .flags = &.{"-std=c++17"},
     });
     gtest.root_module.addIncludePath(gtest_dep.path("googletest/include"));
     gtest.root_module.addIncludePath(gtest_dep.path("googletest"));
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) void {
     gtest_main.linkLibCpp();
     gtest_main.root_module.addCSourceFile(.{
         .file = gtest_dep.path("googletest/src/gtest_main.cc"),
-        .flags = &.{},
+        .flags = &.{"-std=c++17"},
     });
     gtest_main.root_module.addIncludePath(gtest_dep.path("googletest/include"));
     gtest_main.root_module.addIncludePath(gtest_dep.path("googletest"));

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const googletest_dep = b.dependency("googletest", .{});
+    const gtest_dep = b.dependency("googletest", .{});
 
     const gtest = b.addLibrary(.{
         .name = "gtest",
@@ -16,12 +16,12 @@ pub fn build(b: *std.Build) void {
     gtest.linkLibC();
     gtest.linkLibCpp();
     gtest.root_module.addCSourceFile(.{
-        .file = googletest_dep.path("googletest/src/gtest-all.cc"),
+        .file = gtest_dep.path("googletest/src/gtest-all.cc"),
         .flags = &.{},
     });
-    gtest.root_module.addIncludePath(googletest_dep.path("googletest/include"));
-    gtest.root_module.addIncludePath(googletest_dep.path("googletest"));
-    gtest.installHeadersDirectory(googletest_dep.path("googletest/include"), ".", .{});
+    gtest.root_module.addIncludePath(gtest_dep.path("googletest/include"));
+    gtest.root_module.addIncludePath(gtest_dep.path("googletest"));
+    gtest.installHeadersDirectory(gtest_dep.path("googletest/include"), ".", .{});
     b.installArtifact(gtest);
 
     const gtest_main = b.addLibrary(.{
@@ -34,11 +34,11 @@ pub fn build(b: *std.Build) void {
     gtest_main.linkLibC();
     gtest_main.linkLibCpp();
     gtest_main.root_module.addCSourceFile(.{
-        .file = googletest_dep.path("googletest/src/gtest_main.cc"),
+        .file = gtest_dep.path("googletest/src/gtest_main.cc"),
         .flags = &.{},
     });
-    gtest_main.root_module.addIncludePath(googletest_dep.path("googletest/include"));
-    gtest_main.root_module.addIncludePath(googletest_dep.path("googletest"));
-    gtest_main.installHeadersDirectory(googletest_dep.path("googletest/include"), ".", .{});
+    gtest_main.root_module.addIncludePath(gtest_dep.path("googletest/include"));
+    gtest_main.root_module.addIncludePath(gtest_dep.path("googletest"));
+    gtest_main.installHeadersDirectory(gtest_dep.path("googletest/include"), ".", .{});
     b.installArtifact(gtest_main);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "1.15.2",
     .dependencies = .{
         .googletest = .{
-            .url = "https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz",
-            .hash = "122001093b5794ecf5a5b53887622c75d633af2b0c3402a266ce45c6aa4d179c53ba",
+            .url = "https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz",
+            .hash = "N-V-__8AAEV8PgDOBc81AuVJQ9XhGo46f-4dlQ7sXar_M0_i",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "googletest",
+    .name = .googletest,
     .version = "1.15.2",
     .dependencies = .{
         .googletest = .{
@@ -12,4 +12,6 @@
         "build.zig.zon",
         "LICENSE",
     },
+    .minimum_zig_version = "0.15.2",
+    .fingerprint = 0xc36e6f7ae639b5bc,
 }


### PR DESCRIPTION
This includes the following changes:

1. Updates `build.zig` to build with Zig 0.15.2
2. Bumps the googletest dependency to 1.17.0
3. Adds a step for building the bundled samples
4. Adds building the samples to CI
5. Updates the action versions in `build.yml`
6. Adds a README

I expect the checks will fail because they're using the workflow defined in `main` which uses Zig 0.13.0. You can find a passing CI run on my fork.