### PR TITLE
fix: bump gtest version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .googletest,
-    .version = "1.15.2",
+    .version = "1.17.0",
     .dependencies = .{
         .googletest = .{
             .url = "https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz",
@@ -15,3 +15,4 @@
     .minimum_zig_version = "0.16.0",
     .fingerprint = 0xc36e6f7ae639b5bc,
 }
+


### PR DESCRIPTION
hope all is well

came back to my project and used the upstream package instead of mine,
saw that the version in the package manifest; .zon file did not match the artifact release

bumped gtest version 1.15.2 -> 1.17.0
